### PR TITLE
skip cgroup destroy

### DIFF
--- a/libcontainer/state_linux.go
+++ b/libcontainer/state_linux.go
@@ -44,7 +44,9 @@ func destroy(c *linuxContainer) error {
 			logrus.Warn(err)
 		}
 	}
-	err := c.cgroupManager.Destroy()
+	var err error
+	//err := c.cgroupManager.Destroy()
+	fmt.Printf("Skip destroy cgroup!")
 	if rerr := os.RemoveAll(c.root); err == nil {
 		err = rerr
 	}


### PR DESCRIPTION
skip cgroup manager, so skip destroy cgroup at state_linux.go